### PR TITLE
Removes interceptors, adds Handler error return[BREAKING]

### DIFF
--- a/spaces/kernel/interfaces.go
+++ b/spaces/kernel/interfaces.go
@@ -6,19 +6,7 @@ import (
 )
 
 // Handler is a function type that handles messages published to a topic.
-type Handler[T any] func(ctx context.Context, topic string, data T)
-
-// Interceptor is a function type that can intercept messages as they are published to a topic
-// before they reach the handlers. If cont is false, the message will not be published and will
-// not go to any other Interceptors. However, Publish will not return an error. If err is not nil,
-// the same thing will happen, but Publish will return an error.
-// If a message needs a response, the Interceptor is responsible for that.
-// Be careful with Interceptors, as they are executed in order and unlike messages sent to module handlers,
-// this is executed in a single goroutine. Interceptors with long-running operations can muck up performance.
-// Interceptors can use the * topic, which will intercept all messages. This should only be done if the Interceptor
-// needs to manipulate all messages or deny messages from being published. Otherwise, it is better to have a module
-// that listens on all topics.
-type Interceptor[T any] func(ctx context.Context, topic string, api API[T], data T) (cont bool, err error)
+type Handler[T any] func(ctx context.Context, topic string, data T) error
 
 // API provide an interface for modules to interact within the kernel.
 // The API interface can be extended at any time. If implementing a fake API for testing, embed

--- a/spaces/kernel/kernel.go
+++ b/spaces/kernel/kernel.go
@@ -183,8 +183,8 @@ func (k *Kernel[T]) Unsubscribe(topic string, m Module[T]) {
 	}
 }
 
-// Publish sends a message to all modules subscribed to the specified topic. It will return an error if the kernel has not started,
-// if there are no subscribers for the topic, or if an error occurs while running interceptors. If there are wildcard subscribers
+// Publish sends a message to all modules subscribed to the specified topic. It will return an error if the kernel has not started
+// or if there are no subscribers for the topic. If there are wildcard subscribers
 // but no topic specific subscribers, it will still send the message to those wildcard subscribers.
 func (k *Kernel[T]) Publish(ctx context.Context, topic string, data T) error {
 	if !k.started {


### PR DESCRIPTION
By adding a returned error to Handler (which the overall system ignores), we can replace Interceptors with just Handler wrappers.  

This greatly simplifies the code and borrows from net/http, making it more Go standard.